### PR TITLE
Windows Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
   "tags": ["artifactory"],
   "operatingsystem_support": [
     { "operatingsystem": "RedHat", "operatingsystemmajrelease": [ "6", "7" ] },
-    { "operatingsystem": "CentOS", "operatingsystemmajrelease": [ "6", "7" ] }
+    { "operatingsystem": "CentOS", "operatingsystemmajrelease": [ "6", "7" ] },
+    { "operatingsystem": "Windows", "operatingsystemmajrelease": [ "7", "2012" ] }
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }


### PR DESCRIPTION
Artifactory fetch functionality were extended with Windows support. Tested on Windows 7 and Windows 2012 releases. Download using BITS module.