### PR TITLE
Contain classes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class artifactory(
   $ajp_port         = 8019,
   $data_path        = '/var/opt/jfrog/artifactory/data',
   $backup_path      = undef,
+  $create_data_path = true,
 ) {
 
   Class['::java']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,10 +35,15 @@ class artifactory(
   $backup_path      = undef,
 ) {
 
-  include ::java
+  Class['::java']
+  -> Class['::artifactory::install']
+  -> Class['::artifactory::config']
+  -> Class['::artifactory::service']
 
-  class { '::artifactory::install': } ->
-  class { '::artifactory::config': } ->
-  class { '::artifactory::service': }
+  contain '::java'
+  contain '::artifactory::install'
+  contain '::artifactory::config'
+  contain '::artifactory::service'
+
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,10 +13,6 @@ class artifactory::install {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  File {
-    require => Package['artifactory'],
-  }
-
   user { 'artifactory':
     ensure => 'present',
     system => true,
@@ -45,11 +41,16 @@ class artifactory::install {
       mode   => '0775',
       owner  => artifactory,
       group  => artifactory,
+      before => Package['artifactory'],
     }
 
     file { '/var/opt/jfrog/artifactory/data':
       ensure => link,
       target => $::artifactory::data_path,
+      before => [
+        Package['artifactory'],
+        File[$::artifactory::data_path],
+      ]
     }
   }
 
@@ -59,7 +60,7 @@ class artifactory::install {
       mode   => '0775',
       owner  => artifactory,
       group  => artifactory,
+      before => Package['artifactory'],
     }
   }
-
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,7 +35,7 @@ class artifactory::install {
     require  => [ User['artifactory'], Group['artifactory'] ],
   }
 
-  if $::artifactory::data_path != '/var/opt/jfrog/artifactory/data' {
+  if $::artifactory::data_path != '/var/opt/jfrog/artifactory/data' and $::artifactory::create_data_path {
     file { $::artifactory::data_path:
       ensure => directory,
       mode   => '0775',


### PR DESCRIPTION
I found that when used with other modules ordering was difficult, mostly due to:

```
  File {
    require => Package['artifactory'],
  }
```
This PR removes the above blanket precedence statement and replaces it with
explicit ordering and containment.  Furthermore, it adds a `create_data_path=true`
parameter to the main class allowing for override to omit creating the data path
directory should it already be being managed by puppet elsewhere in the catalog -
the default ensuring that existing behaviour is preserved.